### PR TITLE
Updates wazero to its first beta

### DIFF
--- a/wazero/x/go.mod
+++ b/wazero/x/go.mod
@@ -2,4 +2,4 @@ module wa
 
 go 1.18
 
-require github.com/tetratelabs/wazero v0.0.0-20220624054950-1489a9f19f39
+require github.com/tetratelabs/wazero v1.0.0-beta.1

--- a/wazero/x/go.sum
+++ b/wazero/x/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v0.0.0-20220624054950-1489a9f19f39 h1:/fDeuRzphnKe8XTCELxO26d85xbF7Zt2enVFKnlJiZU=
-github.com/tetratelabs/wazero v0.0.0-20220624054950-1489a9f19f39/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v1.0.0-beta.1 h1:O5DZxiXG0WUUjuq4dwomA5gODRNnzF8LzQ+UOqGY5kY=
+github.com/tetratelabs/wazero v1.0.0-beta.1/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=

--- a/wazero/x/wa.go
+++ b/wazero/x/wa.go
@@ -25,9 +25,9 @@ func do(wasm []byte, interpreted bool) {
 
 	var r wazero.Runtime
 	if interpreted {
-		r = wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfigInterpreter().WithWasmCore2())
+		r = wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigInterpreter().WithWasmCore2())
 	} else {
-		r = wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithWasmCore2())
+		r = wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithWasmCore2())
 	}
 	defer r.Close(ctx)
 


### PR DESCRIPTION
This updates to the first beta release of [wazero](https://wazero.io), 1.0.0-beta.1.

Future betas will release at the end of each month until 1.0 in February 2023.

Note: [Release notes](https://github.com/tetratelabs/wazero/releases) will be posted in the next day or two.

Meanwhile, we've also opened a [gophers slack](https://gophers.slack.com/) `#wazero` channel for support, updates and conversation!